### PR TITLE
Implement and run `isort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,12 @@ repos:
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --preserve-quotes, --indent, '2']
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.8.1
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
   hooks:
-  - id: reorder-python-imports
-    args: [--application-directories, '.:src']
+  - id: isort
+    name: isort
+    args: ["--reverse-relative", "--force-single-line-imports"]
 - repo: https://github.com/psf/black
   rev: 22.6.0
   hooks:

--- a/src/planingfsi/__init__.py
+++ b/src/planingfsi/__init__.py
@@ -15,7 +15,6 @@ logger.setLevel(logging.INFO)
 
 from .fe.femesh import Mesh
 
-
 # # Use tk by default. Otherwise try Agg. Otherwise, disable plotting.
 # _fallback_engine = "Agg"
 # if os.environ.get("DISPLAY") is None:

--- a/src/planingfsi/fe/felib.py
+++ b/src/planingfsi/fe/felib.py
@@ -1,9 +1,9 @@
 import abc
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/src/planingfsi/fe/rigid_body.py
+++ b/src/planingfsi/fe/rigid_body.py
@@ -6,16 +6,17 @@ from typing import Optional
 
 import numpy as np
 
+from planingfsi.solver import RootFinder
+
 from . import felib as fe
 from . import substructure
+from .structure import StructuralSolver
 from .. import logger
 from .. import solver
 from .. import trig
 from .. import writers
 from ..config import Config
 from ..dictionary import load_dict_from_file
-from .structure import StructuralSolver
-from planingfsi.solver import RootFinder
 
 
 class RigidBody:

--- a/src/planingfsi/fe/structure.py
+++ b/src/planingfsi/fe/structure.py
@@ -1,9 +1,9 @@
 import os
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Type
-from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/src/planingfsi/fe/substructure.py
+++ b/src/planingfsi/fe/substructure.py
@@ -1,5 +1,6 @@
 import abc
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -8,7 +9,6 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Type
-from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.interpolate import interp1d
@@ -19,13 +19,13 @@ from .. import logger
 from .. import math_helpers
 from .. import trig
 from .. import writers
-from ..config import Config
 from ..config import NUM_DIM
+from ..config import Config
 
 if TYPE_CHECKING:
-    from ..fsi.interpolator import Interpolator
     from .rigid_body import RigidBody
     from .structure import StructuralSolver
+    from ..fsi.interpolator import Interpolator
 
 
 class Substructure(abc.ABC):

--- a/src/planingfsi/fsi/figure.py
+++ b/src/planingfsi/fsi/figure.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import List
-from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/src/planingfsi/fsi/simulation.py
+++ b/src/planingfsi/fsi/simulation.py
@@ -1,20 +1,21 @@
 """High-level control of a `planingfsi` simulation."""
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Union
 
 import numpy as np
 
 # TODO: There is an import cycle making this noreorder line necessary
 from planingfsi.config import Config
-from .. import logger
-from ..dictionary import load_dict_from_file
-from .. import writers
-from ..potentialflow.solver import PotentialPlaningSolver
+
 from .interpolator import Interpolator
+from .. import logger
+from .. import writers
+from ..dictionary import load_dict_from_file
+from ..potentialflow.solver import PotentialPlaningSolver
 
 
 class Simulation:

--- a/src/planingfsi/potentialflow/solver.py
+++ b/src/planingfsi/potentialflow/solver.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy.optimize import fmin
 
 from . import pressurepatch
+from .pressureelement import PressureElement
 from .. import logger
 from .. import math_helpers
 from .. import solver
@@ -16,7 +17,6 @@ from .. import writers
 from ..config import Config
 from ..fsi import figure
 from ..fsi import simulation as fsi_simulation
-from .pressureelement import PressureElement
 
 
 class PotentialPlaningSolver:

--- a/tests/test_structural_solver.py
+++ b/tests/test_structural_solver.py
@@ -6,10 +6,10 @@ from typing import Type
 import numpy
 import pytest
 
-from planingfsi.fsi.simulation import Simulation  # noreorder
+import planingfsi.fe.substructure as ss
 from planingfsi.fe.rigid_body import RigidBody
 from planingfsi.fe.structure import StructuralSolver
-import planingfsi.fe.substructure as ss
+from planingfsi.fsi.simulation import Simulation  # noreorder
 
 
 @pytest.fixture()


### PR DESCRIPTION
Replaces `reorder-python-imports` hook with `isort` in `.pre-commit-config.yaml`