### PR TITLE
bugfix: Revert regressions

### DIFF
--- a/src/planingfsi/potentialflow/pressurepatch.py
+++ b/src/planingfsi/potentialflow/pressurepatch.py
@@ -147,10 +147,8 @@ class PressurePatch(abc.ABC):
         """
         return sum(el.get_influence(x) for el in self.pressure_elements)
 
-    @abc.abstractmethod
     def calculate_forces(self) -> None:
         """Calculate the force components for this pressure patch."""
-        raise NotImplementedError
 
     @property
     def drag_wave(self) -> float:

--- a/src/planingfsi/potentialflow/solver.py
+++ b/src/planingfsi/potentialflow/solver.py
@@ -161,8 +161,8 @@ class PotentialPlaningSolver:
         # TODO: This calculation may be sped up by using vectorized functions
         # Form lists of unknown and source elements
         unknown_el = [el for el in self.pressure_elements if not el.is_source and el.width > 0.0]
-        nan_el = (el for el in self.pressure_elements if el.width <= 0.0)
-        source_el = (el for el in self.pressure_elements if el.is_source)
+        nan_el = [el for el in self.pressure_elements if el.width <= 0.0]
+        source_el = [el for el in self.pressure_elements if el.is_source]
         # Form arrays to build linear system
         # x location of unknown elements
         x_array = np.array([el.x_coord for el in unknown_el])


### PR DESCRIPTION
* Revert change in potential flow solver which changed lists to generators
* Remove the `@abstractmethod` decorator, since `PressureCushion` no longer implements the `calculate_forces()` method