### PR TITLE
[fix(ci)] Remove `poetry` from publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,16 +16,14 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
     - name: Install package dependencies
-      run: poetry install --no-dev
-    - name: Build package
-      run: poetry build
-    - name: Publish package
       run: |
-        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-        poetry publish
+        python -m pip install --upgrade pip
+        python -m pip install build twine
+    - name: Build the package
+      run: python -m build
+    - name: Upload to PyPI with twine
+      run: python -m twine upload ./dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Static type checking
-      continue-on-error: true
-      run: |
-        poetry run mypy .
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Updates the publish pipeline to remove `poetry` in favor of `build` and `twine`.