### PR TITLE
[chore(pkg)] Generate the version number based on the git tag automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ wheels/
 MANIFEST
 poetry.lock
 
+# Generated version file
+src/planingfsi/_version.py
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ license = {text = "MIT"}
 name = "planingfsi"
 readme = "README.md"
 requires-python = ">=3.8,<3.12"
-version = "0.3.1"
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
@@ -108,3 +108,6 @@ legacy_tox_ini = """
   commands = coverage erase
 
 """
+
+[tool.setuptools_scm]
+version_file = "src/planingfsi/_version.py"


### PR DESCRIPTION
Configures `setuptools-scm` to automatically generate the version number from the git tag.